### PR TITLE
#3 i18n interpuctuation

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,11 +26,15 @@ if (flutterVersionName == null) {
 android {
     namespace = "com.anni.dog_sports_diary"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "26.3.11579264"//flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 
     defaultConfig {

--- a/lib/core/utils/string_extensions.dart
+++ b/lib/core/utils/string_extensions.dart
@@ -1,0 +1,5 @@
+extension StringExtension on String {
+  String fixInterpunctuation() {
+    return replaceAll(",", ".");
+  }
+}

--- a/lib/features/diary_entry/diary_entry_tab_state.dart
+++ b/lib/features/diary_entry/diary_entry_tab_state.dart
@@ -6,6 +6,7 @@ import 'package:dog_sports_diary/domain/entities/sports_classes.dart';
 import 'package:dog_sports_diary/features/diary_entry/diary_entry_tab.dart';
 import 'package:dog_sports_diary/features/diary_entry/diary_entry_viewmodel.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_rating/flutter_rating.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -125,7 +126,11 @@ class DiaryEntryTabState extends State<DiaryEntryTab> {
                                   labelText: AppLocalizations.of(context)!.temperature,
                                   suffixText: '°C',
                                 ),
-                                keyboardType: TextInputType.number,
+                                inputFormatters: [FilteringTextInputFormatter.allow(RegExp('[0-9.-]'))],
+                                keyboardType: const TextInputType.numberWithOptions(
+                                  signed: true,
+                                  decimal: true,
+                                ),
                                 onChanged: (value) {
                                   viewModel.updateTemperature(value);
                                 },
@@ -140,7 +145,11 @@ class DiaryEntryTabState extends State<DiaryEntryTab> {
                                     labelText: AppLocalizations.of(context)!.trainingDuration,
                                     suffixText: AppLocalizations.of(context)!.minutes,
                                   ),
-                                  keyboardType: TextInputType.number,
+                                  inputFormatters: [FilteringTextInputFormatter.allow(RegExp('[0-9]'))],
+                                  keyboardType: const TextInputType.numberWithOptions(
+                                    signed: false,
+                                    decimal: false,
+                                  ),
                                   onChanged: (value) {
                                     viewModel.updateTrainingDurationInMin(value);
                                   },
@@ -155,7 +164,11 @@ class DiaryEntryTabState extends State<DiaryEntryTab> {
                                     labelText: AppLocalizations.of(context)!.warumUpDuration,
                                     suffixText: AppLocalizations.of(context)!.minutes,
                                   ),
-                                  keyboardType: TextInputType.number,
+                                  inputFormatters: [FilteringTextInputFormatter.allow(RegExp('[0-9]'))],
+                                  keyboardType: const TextInputType.numberWithOptions(
+                                    signed: false,
+                                    decimal: false,
+                                  ),
                                   onChanged: (value) {
                                     viewModel.updateWarmUpDurationInMin(value);
                                   },
@@ -170,7 +183,11 @@ class DiaryEntryTabState extends State<DiaryEntryTab> {
                                     labelText: AppLocalizations.of(context)!.coolDownDuration,
                                     suffixText: AppLocalizations.of(context)!.minutes,
                                   ),
-                                  keyboardType: TextInputType.number,
+                                  inputFormatters: [FilteringTextInputFormatter.allow(RegExp('[0-9]'))],
+                                  keyboardType: const TextInputType.numberWithOptions(
+                                    signed: false,
+                                    decimal: false,
+                                  ),
                                   onChanged: (value) {
                                     viewModel.updateCoolDownDurationInMin(value);
                                   },

--- a/lib/features/diary_entry/diary_entry_viewmodel.dart
+++ b/lib/features/diary_entry/diary_entry_viewmodel.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:dog_sports_diary/core/di/serivce_provider.dart';
 import 'package:dog_sports_diary/core/utils/constants.dart';
+import 'package:dog_sports_diary/core/utils/string_extensions.dart';
 import 'package:dog_sports_diary/core/utils/tuple.dart';
 import 'package:dog_sports_diary/data/diary/diary_entry_repository.dart';
 import 'package:dog_sports_diary/data/dogs/dog_repository.dart';
@@ -148,7 +149,7 @@ class DiaryEntryViewModel extends ChangeNotifier {
   }
 
   updateTemperature(String temperature) {
-    var temp = double.tryParse(temperature);
+    var temp = double.tryParse(temperature.fixInterpunctuation());
     _diaryEntry = _diaryEntry?.copyWith(temperature: temp);
   }
 

--- a/lib/features/dog/dog_tab_state.dart
+++ b/lib/features/dog/dog_tab_state.dart
@@ -6,6 +6,7 @@ import 'package:dog_sports_diary/domain/entities/sports_classes.dart';
 import 'package:dog_sports_diary/features/dog/dog_tab.dart';
 import 'package:dog_sports_diary/features/dog/dog_viewmodel.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -122,7 +123,11 @@ class DogTabState extends State<DogTab> {
                             suffixText: 'kg',
                             icon: const Icon(Icons.scale),
                           ),
-                          keyboardType: TextInputType.number,
+                          inputFormatters: [FilteringTextInputFormatter.allow(RegExp('[0-9.]'))],
+                          keyboardType: const TextInputType.numberWithOptions(
+                            signed: false,
+                            decimal: true,
+                          ),
                           onChanged: (value) {
                             viewModel.updateWeight(value);
                           },

--- a/lib/features/dog/dog_viewmodel.dart
+++ b/lib/features/dog/dog_viewmodel.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:dog_sports_diary/core/di/serivce_provider.dart';
 import 'package:dog_sports_diary/core/utils/constants.dart';
+import 'package:dog_sports_diary/core/utils/string_extensions.dart';
 import 'package:dog_sports_diary/data/dogs/dog_repository.dart';
 import 'package:dog_sports_diary/domain/entities/dog.dart';
 import 'package:dog_sports_diary/domain/entities/sports.dart';
@@ -117,7 +118,7 @@ class DogViewModel extends ChangeNotifier {
   }
 
   updateWeight(String weightString) {
-    double weight = double.tryParse(weightString) ?? 0.0;
+    double weight = double.tryParse(weightString.fixInterpunctuation()) ?? 0.0;
     _dog = _dog?.copyWith(weight: weight);
   }
 


### PR DESCRIPTION
- fixed gradle version
- missing date picker for #1
- #3 fixed interpunctuation, only allowes . as comma. Textfield where only positive numbers are allowed, only take positive numbers